### PR TITLE
Replace stock ticker display with pickup schedule

### DIFF
--- a/assets/pickup_icons/README.txt
+++ b/assets/pickup_icons/README.txt
@@ -1,0 +1,8 @@
+Place 1-bit (black and white) BMP images for the pickup schedule icons in this folder.
+Each bitmap should be 64x64 pixels to match the layout in paperdash.py.
+Expected filenames:
+- rollerblade.bmp
+- magic.bmp
+- gymnastics.bmp
+- blocks.bmp
+- pilates.bmp


### PR DESCRIPTION
## Summary
- display the Monday-to-Friday pickup schedule in English with pickup times only beside the Kirby graphic
- remove the stock update polling logic now that the UI shows static schedule data

## Testing
- python -m compileall paperdash.py

------
https://chatgpt.com/codex/tasks/task_e_68cd5c4da8d4832181b1b8f9ecf83eaa