### PR TITLE
Adjust weather icon handling

### DIFF
--- a/assets/weather_icons/README.md
+++ b/assets/weather_icons/README.md
@@ -1,0 +1,5 @@
+# Weather Icons Placeholder
+
+Place your `sunny.bmp`, `cloudly.bmp`, `raining.bmp`, and `snow.bmp` bitmaps in this directory.
+They should be monochrome BMP files sized for the PaperDash display (64x64 works well). When an
+icon is missing, PaperDash will automatically use the configured logo instead.

--- a/modules/weather.py
+++ b/modules/weather.py
@@ -1,12 +1,48 @@
-# modules/weather.py
+"""Utilities for retrieving weather information and categorising icons."""
 
 import requests
-from datetime import datetime
 
 LAT = 25.0585178
 LON = 121.6532539
 
+FALLBACK_SUMMARY = "--°C | RH --%"
+
+WEATHER_TEXT_MAP = {
+    0: "Clear",
+    1: "Mostly clr",
+    2: "Partly cldy",
+    3: "Cloudy",
+    45: "Fog",
+    48: "Rime fog",
+    51: "Drizzle",
+    53: "Drizzle",
+    61: "Light rain",
+    63: "Rain",
+    65: "Heavy rain",
+    71: "Snow",
+    80: "Rain showers",
+}
+
+WEATHER_CATEGORY_MAP = {
+    0: "sunny",
+    1: "sunny",
+    2: "sunny",
+    3: "cloudly",
+    45: "cloudly",
+    48: "cloudly",
+    51: "raining",
+    53: "raining",
+    61: "raining",
+    63: "raining",
+    65: "raining",
+    71: "snow",
+    80: "raining",
+}
+
+
 def get_weather_summary():
+    """Return a tuple with display text and icon category for the current weather."""
+
     try:
         url = (
             f"https://api.open-meteo.com/v1/forecast?"
@@ -23,29 +59,20 @@ def get_weather_summary():
         code = current.get("weathercode")
 
         if temp is None or rh is None or code is None:
-            return "Weather: --"
+            return FALLBACK_SUMMARY, "unknown"
 
-        summary = f"{temp:.1f}°C | RH {rh}% | {weather_code_to_text(code)}"
-        return summary
+        summary = f"{temp:.1f}°C | RH {rh}%"
+        category = weather_code_to_category(code)
+        return summary, category
 
     except Exception:
-        return "Weather: --"
+        return FALLBACK_SUMMARY, "unknown"
+
 
 def weather_code_to_text(code):
-    mapping = {
-        0: "Clear",
-        1: "Mostly clr",
-        2: "Partly cldy",
-        3: "Cloudy",
-        45: "Fog",
-        48: "Rime fog",
-        51: "Drizzle",
-        53: "Drizzle",
-        61: "Light rain",
-        63: "Rain",
-        65: "Heavy rain",
-        71: "Snow",
-        80: "Rain showers",
-    }
-    return mapping.get(code, "Unknown")
+    return WEATHER_TEXT_MAP.get(code, "Unknown")
+
+
+def weather_code_to_category(code):
+    return WEATHER_CATEGORY_MAP.get(code, "unknown")
 


### PR DESCRIPTION
## Summary
- remove the committed weather icon bitmaps, restore the bitmap ignore rule, and document where to place custom icons
- make the weather icon loader tolerate missing files without noisy warnings and tweak the left-column centering of the weather text
- map weather code 80 to the raining icon category so showers no longer pick the snow asset

## Testing
- python -m py_compile modules/weather.py paperdash.py

------
https://chatgpt.com/codex/tasks/task_e_68ce0431497c8321afb351cf965b8ae6