### PR TITLE
Center weather icon and update asset guidance

### DIFF
--- a/assets/weather_icons/README.md
+++ b/assets/weather_icons/README.md
@@ -1,5 +1,23 @@
 # Weather Icons Placeholder
 
-Place your `sunny.bmp`, `cloudly.bmp`, `raining.bmp`, and `snow.bmp` bitmaps in this directory.
-They should be monochrome BMP files sized for the PaperDash display (64x64 works well). When an
-icon is missing, PaperDash will automatically use the configured logo instead.
+PaperDash expects you to provide monochrome 300×300 BMP icons for each weather
+condition listed below. Place the bitmaps in this folder using the exact file
+names so the dashboard can discover them at runtime.
+
+| Weather code | Display text  | Bitmap filename        |
+|--------------|---------------|------------------------|
+| 0            | Clear         | `clear.bmp`            |
+| 1            | Mostly clr    | `mostly_clear.bmp`     |
+| 2            | Partly cldy   | `partly_cloudy.bmp`    |
+| 3            | Cloudy        | `cloudy.bmp`           |
+| 45           | Fog           | `fog.bmp`              |
+| 48           | Rime fog      | `rime_fog.bmp`         |
+| 51           | Drizzle       | `drizzle.bmp`          |
+| 61           | Light rain    | `light_rain.bmp`       |
+| 63           | Rain          | `rain.bmp`             |
+| 65           | Heavy rain    | `heavy_rain.bmp`       |
+| 71           | Snow          | `snow.bmp`             |
+| 80           | Rain showers  | `rain_showers.bmp`     |
+
+If an icon file is missing, PaperDash automatically falls back to the configured
+logo so the dashboard still renders cleanly.

--- a/modules/weather.py
+++ b/modules/weather.py
@@ -24,19 +24,19 @@ WEATHER_TEXT_MAP = {
 }
 
 WEATHER_CATEGORY_MAP = {
-    0: "sunny",
-    1: "sunny",
-    2: "sunny",
-    3: "cloudly",
-    45: "cloudly",
-    48: "cloudly",
-    51: "raining",
-    53: "raining",
-    61: "raining",
-    63: "raining",
-    65: "raining",
+    0: "clear",
+    1: "mostly_clear",
+    2: "partly_cloudy",
+    3: "cloudy",
+    45: "fog",
+    48: "rime_fog",
+    51: "drizzle",
+    53: "drizzle",
+    61: "light_rain",
+    63: "rain",
+    65: "heavy_rain",
     71: "snow",
-    80: "raining",
+    80: "rain_showers",
 }
 
 

--- a/paperdash.py
+++ b/paperdash.py
@@ -42,10 +42,18 @@ ICON_TEXT_GAP = 4  # tightened spacing between the time text and icon
 _ICON_CACHE: Dict[str, Optional[Image.Image]] = {}
 
 WEATHER_ICON_FILES = {
-    "sunny": "assets/weather_icons/sunny.bmp",
-    "cloudly": "assets/weather_icons/cloudly.bmp",
-    "raining": "assets/weather_icons/raining.bmp",
+    "clear": "assets/weather_icons/clear.bmp",
+    "mostly_clear": "assets/weather_icons/mostly_clear.bmp",
+    "partly_cloudy": "assets/weather_icons/partly_cloudy.bmp",
+    "cloudy": "assets/weather_icons/cloudy.bmp",
+    "fog": "assets/weather_icons/fog.bmp",
+    "rime_fog": "assets/weather_icons/rime_fog.bmp",
+    "drizzle": "assets/weather_icons/drizzle.bmp",
+    "light_rain": "assets/weather_icons/light_rain.bmp",
+    "rain": "assets/weather_icons/rain.bmp",
+    "heavy_rain": "assets/weather_icons/heavy_rain.bmp",
     "snow": "assets/weather_icons/snow.bmp",
+    "rain_showers": "assets/weather_icons/rain_showers.bmp",
 }
 
 _WEATHER_ICON_CACHE: Dict[str, Optional[Image.Image]] = {}
@@ -160,7 +168,9 @@ def main():
                 # Logo
                 if weather_image:
                     weather_wi, weather_hi = weather_image.size
-                    image.paste(weather_image, (10, height - weather_hi - 10))
+                    left_region_width = width // 2
+                    weather_icon_x = max(0, (left_region_width - weather_wi) // 2)
+                    image.paste(weather_image, (weather_icon_x, height - weather_hi - 10))
 
                 # Schedule section
                 schedule_height = ROW_HEIGHT * len(SCHEDULE)


### PR DESCRIPTION
## Summary
- document that weather icons should be provided as monochrome 300×300 BMP files
- remove the placeholder weather bitmap assets from the repository
- center the weather icon within the left half of the dashboard while keeping its vertical placement

## Testing
- python -m compileall modules/weather.py paperdash.py

------
https://chatgpt.com/codex/tasks/task_e_68df931ee6e0832198352c4adfbee663